### PR TITLE
Make Buttons smaller

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,6 +173,9 @@ func main() {
 		}
 	}
 
+	outerOrientation = gtk.ORIENTATION_VERTICAL
+	innerOrientation = gtk.ORIENTATION_HORIZONTAL
+
 	if *position == "bottom" || *position == "top" {
 		if *position == "bottom" {
 			layershell.SetAnchor(win, layershell.LAYER_SHELL_EDGE_BOTTOM, true)
@@ -245,7 +248,7 @@ func main() {
 	win.Add(outerBox)
 
 	alignmentBox, _ := gtk.BoxNew(innerOrientation, 0)
-	outerBox.PackStart(alignmentBox, true, true, 0)
+	outerBox.PackStart(alignmentBox, true, false, 0)
 
 	mainBox, _ := gtk.BoxNew(innerOrientation, 0)
 	mainBox.SetHomogeneous(true)


### PR DESCRIPTION
I noticed, that buttons use up the entire height/width of the window. I think this looks very awfull, when using the full-screen mode. This patch fixes that, by having the `alignmentBox` only take up the necessary space and not fill the entire screen. (The buttons still fill the space in the `mainBox`, so they all look uniform, with an identical size.)

I also added default values for `outerOrientation` and `innerOrientation`, because these were not set, when not using the `-p` option. This is necessary, to make the `alignmentBox` smaller, because the `fill` argument for `PackStart` does nothing if the Box has no orientation.